### PR TITLE
fix models.conv_iResNet.conv_iResNet.set_num_terms()

### DIFF
--- a/models/conv_iResNet.py
+++ b/models/conv_iResNet.py
@@ -589,8 +589,7 @@ class conv_iResNet(nn.Module):
 
     def set_num_terms(self, n_terms):
         for block in self.stack:
-            for layer in block.stack:
-                layer.numSeriesTerms = n_terms
+            block.numSeriesTerms = n_terms
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

The conv_iResNet, different with multiscale_conv_iResNet, does not have layers in block.stack.